### PR TITLE
Added sprockets for asset compilation.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,9 @@ idea {
           buildConfiguration(delegate,
               'service',
               'boot',
-              'rosetta.boot.Main')
+              'rosetta.boot.Main',
+              "--assets $projectDir/service/src/main/resources/assets",
+          )
         })
       }
     }

--- a/service-acceptance/build.gradle
+++ b/service-acceptance/build.gradle
@@ -9,6 +9,7 @@ dependencies {
   compile 'org.rubygems:rspec:2.11.0'
   compile 'org.rubygems:httparty:0.9.0'
   compile 'org.rubygems:childprocess:0.3.6'
+  compile 'org.rubygems:therubyrhino:2.0.0'
 }
 
 sourceSets {

--- a/service-acceptance/src/test/ruby/ping_spec.rb
+++ b/service-acceptance/src/test/ruby/ping_spec.rb
@@ -20,7 +20,7 @@ describe 'application jar' do
 
       retry_count = 0
       begin
-        response = Rosetta::Client.new.get 'http://localhost:9999/ping'
+        response = Rosetta::Client.new("http://localhost:9999").get '/ping'
       rescue Errno::ECONNREFUSED => e
         sleep 1
         retry_count = retry_count + 1

--- a/service-acceptance/src/test/ruby/ping_spec.rb
+++ b/service-acceptance/src/test/ruby/ping_spec.rb
@@ -15,23 +15,7 @@ describe 'application jar' do
     end
 
     it "should have a ping resource" do
-      process = build_process "--port", "9999"
-      process.start
-
-      retry_count = 0
-      begin
-        response = Rosetta::Client.new("http://localhost:9999").get '/ping'
-      rescue Errno::ECONNREFUSED => e
-        sleep 1
-        retry_count = retry_count + 1
-        if retry_count > 10
-          raise e
-        else
-          retry
-        end
-      end
-
-      response.code.should == 200
+      client.get('/ping').code.should == 200
     end
   end
 end

--- a/service-acceptance/src/test/ruby/spec_helper.rb
+++ b/service-acceptance/src/test/ruby/spec_helper.rb
@@ -2,9 +2,11 @@ require 'httparty'
 
 module Rosetta
   class Client
-    def self.new
+    def self.new base_uri
       ::Class.new do
         include HTTParty
+
+        base_uri base_uri
       end
     end
   end

--- a/service-acceptance/src/test/ruby/spec_helper.rb
+++ b/service-acceptance/src/test/ruby/spec_helper.rb
@@ -1,0 +1,41 @@
+require 'httparty'
+
+module Rosetta
+  class Client
+    def self.new
+      ::Class.new do
+        include HTTParty
+      end
+    end
+  end
+end
+
+module Rosetta
+  module Acceptance
+    module DSL
+      def self.included base
+        base.send(:extend, ClassMethods)
+      end
+
+      module ClassMethods
+        def resource name, &block
+          context name do
+            before(:each) { `unzip #{ENV["ARTIFACT"]} -d #{workdir}` }
+
+            let(:workdir) { Dir.mktmpdir }
+
+            instance_eval &block
+          end
+        end
+      end
+
+      def build_process *args
+        ChildProcess.build(*([File.join(workdir, "/service/bin/service")] + args)).tap do |p|
+          p.io.inherit! if ENV["DEBUG"]
+          at_exit { p.stop }
+        end
+      end
+    end
+  end
+end
+

--- a/service-acceptance/src/test/ruby/sprockets_spec.rb
+++ b/service-acceptance/src/test/ruby/sprockets_spec.rb
@@ -12,7 +12,7 @@ describe "sprockets" do
 
       retry_count = 0
       begin
-        response = Rosetta::Client.new.get 'http://localhost:9999/assets/calculator.js'
+        response = Rosetta::Client.new("http://localhost:9999").get '/assets/calculator.js'
       rescue Errno::ECONNREFUSED => e
         sleep 1
         retry_count = retry_count + 1

--- a/service-acceptance/src/test/ruby/sprockets_spec.rb
+++ b/service-acceptance/src/test/ruby/sprockets_spec.rb
@@ -6,28 +6,13 @@ describe "sprockets" do
 
   resource "assets" do
     it "should successfully compile coffeescript" do
-
-      process = build_process "--port", "9999"
-      process.start
-
-      retry_count = 0
-      begin
-        response = Rosetta::Client.new("http://localhost:9999").get '/assets/calculator.js'
-      rescue Errno::ECONNREFUSED => e
-        sleep 1
-        retry_count = retry_count + 1
-        if retry_count > 10
-          raise e
-        else
-          retry
-        end
-      end
+      response = client.get('/assets/ping.js')
 
       response.code.should == 200
 
       Rhino::Context.open do |context|
         context.eval(response.body)
-        context.eval("square(3)").should == 9
+        context.eval("ping()").should == "PONG"
       end
     end
   end

--- a/service/src/main/java/rosetta/boot/Application.java
+++ b/service/src/main/java/rosetta/boot/Application.java
@@ -49,6 +49,7 @@ public class Application {
         @Provides
         public Server server(Arguments arguments) throws IOException, URISyntaxException {
             Server server = new Server(arguments.port());
+            System.setProperty("asset.root", arguments.assets());
 
             HandlerCollection handlers = new HandlerCollection();
 

--- a/service/src/main/java/rosetta/boot/Arguments.java
+++ b/service/src/main/java/rosetta/boot/Arguments.java
@@ -2,4 +2,5 @@ package rosetta.boot;
 
 public interface Arguments {
     Integer port();
+    String assets();
 }

--- a/service/src/main/resources/assets/calculator.js.coffee
+++ b/service/src/main/resources/assets/calculator.js.coffee
@@ -1,0 +1,1 @@
+this.square = (x) -> x * x

--- a/service/src/main/resources/assets/calculator.js.coffee
+++ b/service/src/main/resources/assets/calculator.js.coffee
@@ -1,1 +1,0 @@
-this.square = (x) -> x * x

--- a/service/src/main/resources/assets/ping.js.coffee
+++ b/service/src/main/resources/assets/ping.js.coffee
@@ -1,0 +1,1 @@
+this.ping = -> "PONG"

--- a/service/src/main/ruby/config.ru
+++ b/service/src/main/ruby/config.ru
@@ -1,4 +1,25 @@
 require 'rubygems'
+
+require 'stdlib/patches/pathname'
+
+require 'rack'
+
+require 'sprockets'
+require 'coffee-script'
+
 require 'rosetta/routing'
 
-run Rosetta::Routing
+run Rack::Builder.new {
+  map "/assets" do
+    asset_root = java.lang.System.getProperty("asset.root") or raise "System.getProperty(\"asset.root\") undefined."
+
+    environment = Sprockets::Environment.new asset_root
+    environment.append_path '.'
+
+    run environment
+  end
+
+  map "/" do
+    run Rosetta::Routing
+  end
+}

--- a/service/src/main/ruby/rosetta/cli.rb
+++ b/service/src/main/ruby/rosetta/cli.rb
@@ -2,9 +2,16 @@ require 'clamp'
 
 module Rosetta
   class Cli < Clamp::Command
+    def self.classpath_resource name
+      Java::JavaLang::Thread.current_thread.context_class_loader.get_resource(name).path
+    end
+
     option '--port', '-p' 'PORT', 'server port', :default => 3000 do |s|
       Integer(s)
     end
+
+    option '--assets', '-a' 'ASSETS', 'asset root of application',
+           :default => File.join(classpath_resource("assets"), "")
 
     def execute
       Java::RosettaBoot::Application.boot self

--- a/service/src/main/ruby/stdlib/patches/pathname.rb
+++ b/service/src/main/ruby/stdlib/patches/pathname.rb
@@ -1,0 +1,8 @@
+require 'pathname'
+
+class Pathname
+  def absolute?
+    to_s =~ /^file:/ || !relative?
+  end
+end
+


### PR DESCRIPTION
Basic setup of sprockets.
- Dynamic recompilation of assets when running from intellij (by specifying --assets flag)
- Runs fine with gradle run
- Works when used from package

Notes:
   Nasty hack on Pathname to allow for asset loading from classpath. (Requires a JRuby fix.)
   Haven't tried sprockets dependency management stuff yet.
   Using a system property to pass parameters into the rackup...has limitation of single asset.root per application (global state). Maybe figuring out how to access init params is in order?
